### PR TITLE
Port key handling to SDL2

### DIFF
--- a/src/wport.c
+++ b/src/wport.c
@@ -41,39 +41,106 @@ SDL_Window *window = NULL;
 SDL_Renderer *renderer = NULL;
 SDL_Texture *texture = NULL;
 
-int waskey(int key)
+typedef struct
 {
-    // SP-TODO
-    return 0;
+    SDL_Keycode keycode;
+    bool pressed;
+    bool was_pressed;
+} Key;
+
+static Key keys[MAX_NUMBER_OF_PRESSED_KEYS] = { 0 };
+
+Key* find_key(SDL_Keycode keycode)
+{
+    int i;
+    /* Look if key already exists in array */
+    for (i = 0; i < MAX_NUMBER_OF_PRESSED_KEYS; ++i)
+    {
+        if (keys[i].keycode == keycode)
+        {
+            return &keys[i];
+        }
+    }
+    /* Find free entry if key didn't previously exist */
+    for (i = 0; i < MAX_NUMBER_OF_PRESSED_KEYS; ++i)
+    {
+        if (!keys[i].keycode)
+        {
+            return &keys[i];
+        }
+    }
+    /* Out of slots. Should never happen with big enough MAX_NUMBER_OF_PRESSED_KEYS */
+    return NULL;
 }
 
-int key(int key)
+bool waskey(SDL_Keycode key)
 {
-    // SP-TODO
-    return 0;
+    Key* searched_key = find_key(key);
+    if (searched_key)
+    {
+        return searched_key->was_pressed;
+    }
+    return true;
 }
 
-void clearkey(int key)
+bool key(SDL_Keycode key)
 {
-    // SP-TODO
+    Key* searched_key = find_key(key);
+    if (searched_key)
+    {
+        return searched_key->pressed;
+    }
+    return true;
+}
+
+void clearkey(SDL_Keycode key)
+{
+    Key* searched_key = find_key(key);
+    if (searched_key)
+    {
+        searched_key->was_pressed = 0;
+        if (!searched_key->pressed)
+        {
+            searched_key->keycode = 0;
+        }
+    }
 }
 
 void update()
 {
     SDL_Event ev;
+    Key* key = NULL;
 
-    // SP-TODO
     while (SDL_PollEvent(&ev))
     {
 	switch (ev.type)
         {
             case SDL_KEYDOWN:
-                //key(ev.key.keysym.sym) = 1;
-                //waskey(ev.key.keysym.sym) = 1;
+            {
+                const SDL_Keycode pressed = ev.key.keysym.sym;
+                key = find_key(pressed);
+                if (key)
+                {
+                    key->keycode = pressed;
+                    key->pressed = 1;
+                    key->was_pressed = 1;
+                }
                 break;
+            }
             case SDL_KEYUP:
-                //key(ev.key.keysym.sym) = 0;
+            {
+                const SDL_Keycode pressed = ev.key.keysym.sym;
+                key = find_key(pressed);
+                if (key && key->keycode == pressed)
+                {
+                    key->pressed = 0;
+                    if (!key->was_pressed)
+                    {
+                        key->keycode = 0;
+                    }
+                }
                 break;
+            }
             case SDL_QUIT:
                 exit(0);
                 break;

--- a/src/wport.h
+++ b/src/wport.h
@@ -5,7 +5,7 @@
 #ifndef WPORT_H_INCLUDED
 #define WPORT_H_INCLUDED
 
-
+#include <stdbool.h>
 #include "SDL.h"
 #include "util/util.h"
 
@@ -39,14 +39,15 @@
 #define K_RIGHT2	SDLK_KP_6
 #define K_DOWN2		SDLK_KP_2
 
-#define SDLK_LAST 256 // SP-TODO
+#define MAX_NUMBER_OF_PRESSED_KEYS 128
+#define SDLK_LAST MAX_NUMBER_OF_PRESSED_KEYS
 
 // flips screen and updates keyboard state
 extern void update();
 
-extern int waskey(int key);
-extern int key(int key);
-extern void clearkey(int key);
+extern bool waskey(SDL_Keycode key);
+extern bool key(SDL_Keycode key);
+extern void clearkey(SDL_Keycode key);
 
 extern volatile short int cstart[768],cdest[768],ctemp[768];
 extern volatile short int realfadecount;


### PR DESCRIPTION
Keep table of keys which are either pressed, or have been pressed and game has not cleared them yet.

Use big `MAX_NUMBER_OF_PRESSED_KEYS` because game clears pressed keys only some times, so to be sure that the array never runs out of free entries and block input in cases where user has pressed a lot of keys.

![kops-1](https://user-images.githubusercontent.com/24453333/65813774-228c7680-e1e2-11e9-91da-8838573b093b.gif)
