### PR TITLE
x64 fixes, SDL uninit and warning fix

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -48,6 +48,8 @@ char musicfile[80];
 #define INIT_WAIT_FOR_KEYPRESS
 //#define INIT_SHOWLEVELLIST
 
+static void uninitGraphics(void);
+
 void initGraphics()
 {
     char sdf[1024];
@@ -61,7 +63,7 @@ void initGraphics()
     }
 
     /* Clean up on exit */
-    atexit(SDL_Quit);
+    atexit(uninitGraphics);
 
     // SDL_WM_SetIcon(SDL_LoadBMP("icon.bmp"), NULL); SP-TODO
 
@@ -135,7 +137,7 @@ void initGraphics()
     }
 }
 
-static void uninitGraphics()
+static void uninitGraphics(void)
 {
     if (texture) SDL_DestroyTexture(texture);
     if (windowSurface) SDL_FreeSurface(windowSurface);

--- a/src/load.c
+++ b/src/load.c
@@ -150,8 +150,8 @@ Uint8 loadconfig()
 void loadlevel(char *filename)
 {
 #define MAXLEVELREVISION  1
-    unsigned long pkpiclen, pkbacklen, levellen, backgrlen, pktransplen, transplen;
-    unsigned int revision;
+    unsigned long levellen, backgrlen, transplen;
+    Uint32 pkpiclen, pkbacklen, pktransplen, revision;
     Uint8 orgsig[8] = { 'K', 'O', 'P', 'S', 'L', 'E', 'V', 26 };
     Uint8 sig[8];
     UTIL_FILE *fp;
@@ -333,7 +333,8 @@ void loadlevel(char *filename)
 
 void loadships(char *filename)
 {
-    unsigned long unpackedsize, packedsize, unpklen;
+    unsigned long unpklen;
+    Uint32 unpackedsize, packedsize;
     Uint8 *pk, *unpk;
     int err;
     UTIL_FILE *fp;
@@ -415,8 +416,8 @@ void loadgfx(char *filename)
     Uint8 bigfontstr[BIGFONTCHRS] =
 	{ "ABCDEFGHIJKLMNOPQRSTUVWXYZ\345\344\3660123456789" "!\"?:.;,+-=@\334\337()/#%$\\_*<>\260\261\262\333\372\371\376 "
         };
-    unsigned long pkgfxlen, gfxlen, unplen;
-    int gfxw, gfxh;
+    unsigned long unplen;
+    Uint32 pkgfxlen, gfxlen, gfxw, gfxh;
     UTIL_FILE *fp;
     Uint8 *packed, *unp;
     Uint8 *tmp;

--- a/src/wport.c
+++ b/src/wport.c
@@ -48,7 +48,7 @@ typedef struct
     bool was_pressed;
 } Key;
 
-static Key keys[MAX_NUMBER_OF_PRESSED_KEYS] = { 0 };
+static Key keys[MAX_NUMBER_OF_PRESSED_KEYS] = { { 0 } };
 
 Key* find_key(SDL_Keycode keycode)
 {


### PR DESCRIPTION
- Fix data loading code which expects that `unsigned long` is 4 bits
   - x64 build starts now
- Fix array initialization warning
- Call `uninitGraphics` which initializes all graphics stuff