### PR TITLE
Fix segfault when picking up ammo

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -743,7 +743,7 @@ void game()
                             if ((ox * ox + oy * oy) <= (PICKDIST * PICKDIST))
                             {
                                 sound_eff(S_COLLECT, 64, 128, 16384, 0);
-                                weapons[p].pick(a, p);
+                                weapons[pickammo[p].type].pick(a, p);
 #if 0
                                 switch (pickammo[p].type)
                                 {


### PR DESCRIPTION
It seems that the code might have been broken when bots have been partially added.

`p` == ammo pickup spot
`weapons` array is indexed with weapon type