### PR TITLE
Reduce busy looping

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -183,8 +183,7 @@ void game()
     while ((!key(K_ESC)) && (!waskey(K_ESC)) && (victory == 0) && (dead < players))
     {
 
-	while (framecounter == 0)
-            ;
+	wait_framecount();
 
 	frm = framecounter;
 	framecounter = 0;

--- a/src/menu.c
+++ b/src/menu.c
@@ -377,9 +377,7 @@ void levelsmenu()
     while (menuexit == 255)
     {
 
-	while (framecounter == 0)
-        {
-	};
+	wait_framecount();
 	menufrm += framecounter;
 	framecounter = 0;
 	/*  logo */
@@ -566,9 +564,7 @@ void optionsmenu()
     while (menuexit == 255)
     {
 
-	while (framecounter == 0)
-        {
-	};
+	wait_framecount();
 	menufrm += framecounter;
 	framecounter = 0;
 
@@ -821,8 +817,7 @@ Uint8 mainmenu()
     while (menuexit == 255)
     {
 
-	while (framecounter == 0)
-            ;
+	wait_framecount();
 
 	menufrm += framecounter;
 	framecounter = 0;

--- a/src/wport.c
+++ b/src/wport.c
@@ -169,6 +169,14 @@ void update()
     SDL_RenderPresent(renderer);
 }
 
+void wait_framecount()
+{
+    while (framecounter == 0)
+    {
+        SDL_Delay(1);
+    }
+}
+
 Uint8 fileexists(char *filename)
 {
     UTIL_FILE *fp;

--- a/src/wport.h
+++ b/src/wport.h
@@ -49,6 +49,8 @@ extern bool waskey(SDL_Keycode key);
 extern bool key(SDL_Keycode key);
 extern void clearkey(SDL_Keycode key);
 
+extern void wait_framecount();
+
 extern volatile short int cstart[768],cdest[768],ctemp[768];
 extern volatile short int realfadecount;
 


### PR DESCRIPTION
Reduce busy looping by adding short sleep. Reduces CPU load. In reality the accuracy of `SDL_Delay` is far from 1 ms, so longer delay could cause stuttering.