### PR TITLE
Initial sound support

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -176,8 +176,7 @@ void info()
     kprintfs(bigfont[0], 25, 130, "music by erkki turunen");
     kprintfs(bigfont[0], 15, 160, "A.I by Sami Makinen-Okubo");
     kprintfs(font, 20, 195, "uses SDL (www.libsdl.org)");
-    kprintfs(font, 20, 210, "and FMOD (www.fmod.org)");
-    kprintfs(font, 20, 225, "and ZLIB (by Jean-loup Gailly and Mark Adler)");
+    kprintfs(font, 20, 210, "and ZLIB (by Jean-loup Gailly and Mark Adler)");
     kprintfs(font, 30, 245, "Additional thanks to Jari Komppa, Pepe Taskinen");
     kprintfs(font, 30, 260, "and Antti Tapaninen");
 

--- a/src/sound_helpers.c
+++ b/src/sound_helpers.c
@@ -1,0 +1,112 @@
+#include "sound_helpers.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <memory.h>
+
+#include "SDL_mixer.h"
+#include "util/utilfile.h"
+
+static const char *temp_file = "tmpfile.s3m";
+
+Mix_Music *load_music_file(char *filename)
+{
+    Mix_Music *music = NULL;
+    UTIL_FILE *handle = util_fopen(filename);
+
+    if (handle) {
+        const size_t data_size = (size_t)handle->fsize;
+
+        if (data_size) {
+            Uint8 *buffer = (Uint8 *)malloc(data_size);
+
+            if (buffer) {
+                if (util_fread(buffer, handle->fsize, 1, handle)) {
+                    FILE *fp = fopen(temp_file, "wb");
+
+                    if (fp) {
+                        if (fwrite(buffer, data_size, 1, fp)) {
+                            fclose(fp);
+                            music = Mix_LoadMUS(temp_file);
+
+                            remove(temp_file);
+                        } else {
+                            fclose(fp);
+                        }
+                    }
+                }
+
+                free(buffer);
+            }
+        }
+
+        util_fclose(handle);
+    }
+
+    return music;
+}
+
+Sample *load_sample_file(char *filename)
+{
+    Sample *sample = NULL;
+    UTIL_FILE *handle = util_fopen(filename);
+
+    if (handle) {
+        const size_t data_size = (size_t)handle->fsize;
+
+        if (data_size) {
+            Uint8 *buffer = (Uint8 *)malloc(data_size);
+
+            if (buffer) {
+                if (util_fread(buffer, handle->fsize, 1, handle)) {
+                    sample = (Sample *)malloc(sizeof(Sample));
+                    memset(sample, 0, sizeof(Sample));
+
+                    sample->audio_buf = buffer;
+                    sample->audio_len = data_size;
+                } else {
+                    free(buffer);
+                }
+            }
+        }
+
+        util_fclose(handle);
+    }
+
+    return sample;
+}
+
+void resample_if_needed(Sample *sample, unsigned rate)
+{
+    if (sample->mix_chunk && sample->mix_rate == rate) {
+        // Resampled audio already cached
+        return;
+    }
+
+    if (sample->mix_chunk) {
+        // Free the previous cached audio
+        Mix_FreeChunk(sample->mix_chunk);
+        sample->mix_chunk = NULL;
+    }
+
+    int dev_freq;
+    uint16_t dev_format;
+    int dev_channels;
+    Mix_QuerySpec(&dev_freq, &dev_format, &dev_channels);
+
+    // Convert from desired sampling rate to device sampling rate. This
+    // resamples the original as if it already had the desired rate.
+    SDL_AudioCVT cvt;
+    SDL_BuildAudioCVT(&cvt,
+                      AUDIO_S8, 1, rate,
+                      dev_format, dev_channels, dev_freq);
+
+    cvt.len = sample->audio_len;
+    cvt.buf = (uint8_t *)malloc(cvt.len * cvt.len_mult);
+    memcpy(cvt.buf, sample->audio_buf, sample->audio_len);
+
+    SDL_ConvertAudio(&cvt);
+
+    sample->mix_chunk = Mix_QuickLoad_RAW(cvt.buf, cvt.len_cvt);
+    sample->mix_rate = rate;
+}

--- a/src/sound_helpers.h
+++ b/src/sound_helpers.h
@@ -1,0 +1,21 @@
+#ifndef SOUND_HELPERS_H_INCLUDED
+#define SOUND_HELPERS_H_INCLUDED
+
+#include "SDL_mixer.h"
+#include "SDL_stdinc.h"
+
+typedef struct {
+    // Original audio
+    Uint8 *audio_buf;
+    Uint32 audio_len;
+
+    // Last resampled audio
+    Mix_Chunk *mix_chunk;
+    unsigned int mix_rate;
+} Sample;
+
+Mix_Music *load_music_file(char *filename);
+Sample *load_sample_file(char *filename);
+void resample_if_needed(Sample *sample, unsigned rate);
+
+#endif /* !SOUND_HELPERS_H_INCLUDED */


### PR DESCRIPTION
Whole music track (consisting of several "order" tracks) are looped, not just the selected "order". KOPS's s3m-file contains several different "orders" which are selected according to UI state (menu, game, after-game screen). Maybe `Mix_HookMusicFinished` could be used to restart the active "order"?

s3m file is first read from `kops.jfl` to memory and stored to temporary file on filesystem. This file is loaded with SDL and file is then removed. Not sure if it could be avoided somehow.