### PR TITLE
Add build flag for the incomplete bot support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,13 @@ endif()
 file(GLOB SOURCES
 	src/*.h src/*.c
 	src/util/*.h src/util/*.c
-	src/kops-bot/reactive-agent/*.h src/kops-bot/reactive-agent/*.c)
+	src/kops-bot/reactive-agent/*.h)
+
+if (EXPERIMENTAL_BOT_SUPPORT)
+	file(GLOB BOT_SOURCES
+		src/kops-bot/reactive-agent/*.c)
+	list(APPEND SOURCES ${BOT_SOURCES})
+endif()
 
 add_executable(${PROJECT_NAME} ${SOURCES})
 
@@ -65,4 +71,9 @@ endif()
 
 if (APPLE)
 	target_compile_definitions(${PROJECT_NAME} PRIVATE PATH_MAX=260)
+endif()
+
+if (EXPERIMENTAL_BOT_SUPPORT)
+	message(STATUS "Enabled incomplete experimental bot support")
+	target_compile_definitions(${PROJECT_NAME} PRIVATE EXPERIMENTAL_BOT_SUPPORT=1)
 endif()

--- a/src/game.c
+++ b/src/game.c
@@ -31,8 +31,11 @@
 #include "spr.h"
 #include "init.h"
 #include "sound.h"
+// Some defines are needed even with bot support disabled
 #include "kops-bot/reactive-agent/cannonfodder.h"
+#if EXPERIMENTAL_BOT_SUPPORT
 #include "kops-bot/reactive-agent/bot-util.h"
+#endif
 
 /* #define VRC */
 /* #define RASTER */
@@ -82,13 +85,17 @@ void preparegame()
         }
     }
 
+#if EXPERIMENTAL_BOT_SUPPORT
     /* Detach all current agents. */
     detachAgents();
+#endif
 
     /* Attach as many agents as required. */
     for (a = MAXPLAYERS; a < (MAXPLAYERS + bots); ++a) {
         if (plr[a].active) {
+#if EXPERIMENTAL_BOT_SUPPORT
             attachAgent(&plr[a]);
+#endif
             plr[a].bot = 1;
             plr[a].action = ACTION_NOT_DEFINED;
             plr[a].fire_rate = 0;
@@ -182,7 +189,9 @@ void game()
 
             pan = 128;
 
+#if EXPERIMENTAL_BOT_SUPPORT
             botHandler();
+#endif
 
             /*
 	     * main loop for all players

--- a/src/menu.c
+++ b/src/menu.c
@@ -174,7 +174,9 @@ void info()
     kprintfs(bigfont[0], 15, 90, "by");
     kprintfs(bigfont[1], 325, 90, "Jetro Lauha");
     kprintfs(bigfont[0], 25, 130, "music by erkki turunen");
+#if EXPERIMENTAL_BOT_SUPPORT
     kprintfs(bigfont[0], 15, 160, "A.I by Sami Makinen-Okubo");
+#endif
     kprintfs(font, 20, 195, "uses SDL (www.libsdl.org)");
     kprintfs(font, 20, 210, "and ZLIB (by Jean-loup Gailly and Mark Adler)");
     kprintfs(font, 30, 245, "Additional thanks to Jari Komppa, Pepe Taskinen");
@@ -704,7 +706,9 @@ Uint8 mainmenu()
     enum menu_options {
         MENU_start,
         MENU_players,
+#if EXPERIMENTAL_BOT_SUPPORT
         MENU_bots,
+#endif
         MENU_levels,
         MENU_ignore,
         MENU_options,
@@ -716,7 +720,9 @@ Uint8 mainmenu()
     char *menustr[MENU_total] = {
         "start game",
         "players < >",
+#if EXPERIMENTAL_BOT_SUPPORT
         "bots < >",
+#endif
         "choose levels",
         "\372\372",
         "options",
@@ -768,8 +774,9 @@ Uint8 mainmenu()
     }
 
     kprintfs(bigfont[0], (640 - strlen(menustr[MENU_players]) * 25) / 2 + 225, 252, "%d", players);
+#if EXPERIMENTAL_BOT_SUPPORT
     kprintfs(bigfont[0], (640 - strlen(menustr[MENU_bots]) * 25) / 2 + 150, 284, "%d", bots);
-
+#endif
     menutmp = (Uint8 *)malloc(640 * 300 + 32 * 32);
     menufrm = 0;
 
@@ -802,11 +809,13 @@ Uint8 mainmenu()
         if (sel == MENU_players) {
             kprintf(menutmp, bigfont[1], (640 - strlen(menustr[MENU_players]) * 25) / 2 + 225,
                     4, 640, "%d", players);
-        } else if (sel == MENU_bots) {
+        }
+#if EXPERIMENTAL_BOT_SUPPORT
+        else if (sel == MENU_bots) {
             kprintf(menutmp, bigfont[1], (640 - strlen(menustr[MENU_bots]) * 25) / 2 + 150,
                     4, 640, "%d", bots);
         }
-
+#endif
         jcsprite((640 - strlen(menustr[sel]) * 25) / 2 - 48, 0,
                  32, 32, 640, menutmp, othgfx[2].pic + ((menufrm / 2 + 32) & 63) * 32 * 32);
         jcscalesprite((640 - strlen(menustr[sel]) * 25) / 2 + strlen(menustr[sel]) * 25 + 48, 8,
@@ -837,11 +846,13 @@ Uint8 mainmenu()
             if (sel == MENU_players) {
                 kprintf(menutmp, bigfont[0], (640 - strlen(menustr[MENU_players]) * 25) / 2 + 225, 4, 640, "%d",
                         players);
-            } else if (sel == MENU_bots) {
+            }
+#if EXPERIMENTAL_BOT_SUPPORT
+            else if (sel == MENU_bots) {
                 kprintf(menutmp, bigfont[0], (640 - strlen(menustr[MENU_bots]) * 25) / 2 + 150, 4, 640, "%d",
                         bots);
             }
-
+#endif
             jvdump((216 + sel * 32) * 640, 640 * 32, menutmp);
 
             if (((waskey(K_UP)) || (waskey(K_UP2))) && (sel > 0)) {
@@ -883,7 +894,9 @@ Uint8 mainmenu()
                     initplayer(players);
                     players++;
                 }
-            } else if (sel == MENU_bots) {
+            }
+#if EXPERIMENTAL_BOT_SUPPORT
+            else if (sel == MENU_bots) {
                 if (((waskey(K_LEFT)) || (waskey(K_LEFT2))) && (bots > 0)) {
                     deinitplayer(MAXPLAYERS + bots - 1);
                     --bots;
@@ -893,6 +906,7 @@ Uint8 mainmenu()
                     ++bots;
                 }
             }
+#endif
             clearkey(K_LEFT);
             clearkey(K_RIGHT);
             clearkey(K_LEFT2);
@@ -914,7 +928,9 @@ Uint8 mainmenu()
                     kprintfs(bigfont[0], (640 - strlen(menustr[a]) * 25) / 2, 220 + a * 32, menustr[a]);
                 }
                 kprintfs(bigfont[0], (640 - strlen(menustr[MENU_players]) * 25) / 2 + 225, 252, "%d", players);
+#if EXPERIMENTAL_BOT_SUPPORT
                 kprintfs(bigfont[0], (640 - strlen(menustr[MENU_bots]) * 25) / 2 + 150, 284, "%d", bots);
+#endif
                 break;
             case MENU_options:
                 optionsmenu();
@@ -923,7 +939,9 @@ Uint8 mainmenu()
                     kprintfs(bigfont[0], (640 - strlen(menustr[a]) * 25) / 2, 220 + a * 32, menustr[a]);
                 }
                 kprintfs(bigfont[0], (640 - strlen(menustr[MENU_players]) * 25) / 2 + 225, 252, "%d", players);
+#if EXPERIMENTAL_BOT_SUPPORT
                 kprintfs(bigfont[0], (640 - strlen(menustr[MENU_bots]) * 25) / 2 + 150, 284, "%d", bots);
+#endif
                 break;
             case MENU_info:
                 info();
@@ -932,7 +950,9 @@ Uint8 mainmenu()
                     kprintfs(bigfont[0], (640 - strlen(menustr[a]) * 25) / 2, 220 + a * 32, menustr[a]);
                 }
                 kprintfs(bigfont[0], (640 - strlen(menustr[1]) * 25) / 2 + 225, 252, "%d", players);
+#if EXPERIMENTAL_BOT_SUPPORT
                 kprintfs(bigfont[0], (640 - strlen(menustr[MENU_bots]) * 25) / 2 + 150, 284, "%d", bots);
+#endif
                 break;
             }
             clearkey(K_ENTER);

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -1223,8 +1223,9 @@ static void pickSpecial(int p, int ammo)
 
 static void pickNextAmmo(int p, int ammo)
 {
-
+#if EXPERIMENTAL_BOT_SUPPORT
     logAccess("pickNextAmmo(%d, %d)\n", p, ammo);
+#endif
 
     pickammo[ammo].active = 0;
     plr[p].activeslot = (Uint8)((plr[p].activeslot + 1) % slots);


### PR DESCRIPTION
Issue #18 

Bot support is disabled by default.

Hide mentions of bots from UI. Support is incomplete and experimental, and was not present in either DOS release nor in SDL1 port release. Add `EXPERIMENTAL_BOT_SUPPORT` build flag which can be used to re-enable bots in case someone wants to continue the development.