### PR TITLE
Key repeat blocking

### DIFF
--- a/src/kops.c
+++ b/src/kops.c
@@ -179,7 +179,7 @@ int main(int argc, char *argv[])
         initgravity();
     }
 
-    //SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY / 2, SDL_DEFAULT_REPEAT_INTERVAL * 2); SP-TODO
+    keyrepeat(true);
 
     while (mainmenu() != 6) {
         for (a = 0; a < players; a++) {
@@ -203,9 +203,9 @@ int main(int argc, char *argv[])
             jinitreal();
             gamewindowbackgrounds();
             loadlevel((char *)(&levlist[a]) + 1);
-            //SDL_EnableKeyRepeat(0, 0); SP-TODO
+            keyrepeat(false);
             game();
-            //SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY / 2, SDL_DEFAULT_REPEAT_INTERVAL * 2); SP-TODO
+            keyrepeat(true);
             jatko = 0;
             if (a < levels - 1) {
                 jatko = statusscreen();

--- a/src/wport.c
+++ b/src/wport.c
@@ -34,6 +34,7 @@
 volatile short int cstart[768], cdest[768], ctemp[768];
 volatile short int realfadecount;
 bool fullscreen = false;
+bool repeat = true;
 
 SDL_Color palette[256];
 SDL_Surface *screen = NULL;
@@ -99,6 +100,11 @@ void clearkey(SDL_Keycode key)
     }
 }
 
+void keyrepeat(bool enabled)
+{
+    repeat = enabled;
+}
+
 void clearkeys()
 {
     memset(&keys, 0, sizeof(keys));
@@ -130,6 +136,9 @@ void update()
             if (handle_special_key(&ev.key)) {
                 break;
             }
+
+            if (!repeat && ev.key.repeat)
+                break;
 
             const SDL_Keycode pressed = ev.key.keysym.sym;
             key = find_key(pressed);

--- a/src/wport.h
+++ b/src/wport.h
@@ -53,6 +53,8 @@ extern bool key(SDL_Keycode key);
 extern void clearkey(SDL_Keycode key);
 extern void clearkeys();
 
+extern void keyrepeat(bool enabled);
+
 extern void wait_framecount();
 
 extern volatile short int cstart[768], cdest[768], ctemp[768];


### PR DESCRIPTION
Issue #19 

No visual change found, but at least it's now like the SDL1 port also has worked. Not sure if it affects in some rare case.

The repeat speed in menus is close enough comparing to original DOS version. SDL1 port has way slower repeat.