### PR TITLE
Travis configuration cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ matrix:
             - g++-8
             - libsdl2-dev
             - libsdl2-mixer-dev
-            - libsdl2-image-dev
-            - libsdl2-net-dev
+            - zlib1g-dev
       before_install:
         - CC=gcc-8 && CXX=g++-8
     - os: linux


### PR DESCRIPTION
Remove unnecessary packages. Install zlib explicitly on Linux.