### PR TITLE
Update manual's version number. Point to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,5 +79,12 @@ cmake ..
 cmake --build .
 ```
 
+Releases
+--------
+
+**Version 1 - 2019-10-14**
+
+- Initial release
+
 [suomipelit-gh]: https://github.com/suomipelit
 [suomipelit-slack]: https://join.slack.com/t/suomipelit/shared_invite/enQtNDg1ODkwODU4MTE4LWExY2Q3Mjc0ODg3OTY3ZjlmYThkZDRlMDBjZWUwM2I4NWZlZTFkMWI4YjM1OTM1ODQ4NGQ1NGFiNjQ5MjY0NzM

--- a/doc/manual.txt
+++ b/doc/manual.txt
@@ -11,7 +11,7 @@
  ##'   "########  `##########'    ###                .########'
           `##"'       "###"       ###                `##""' [Sol]
                                    "#
-Freeware Release User Manual v 1.1
+Freeware Release User Manual v 1.2+sp1
 
 Contents
 1. What's KOPS?
@@ -364,6 +364,8 @@ Solutions:
 | 6. Revision History                                                    |
 `------------------------------------------------------------------------'
 
+Version 1.2+sp1     (October 2019)
+  + See README.md
 Version 1.1         (September 2001)
   + Code cleanups
   + Port level file converter to work with windows/linux


### PR DESCRIPTION
Not exactly sure what's best here. Minimum changes to original manual targeting `1.2-sp1` release. Open for other ideas.