### PR TITLE
Always start game in windowed mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ released as version `1.0`, so there might be some changes to the original.
 
 Changes in SDL2 port:
 
+- Game always starts in windowed mode
+
 - Left alt + return toggles full-screen
 
 - Partial A.I. (bot) code added after `1.0` release has been disabled by

--- a/src/init.c
+++ b/src/init.c
@@ -62,16 +62,6 @@ void initGraphics()
     /* Clean up on exit */
     atexit(uninitGraphics);
 
-#ifdef NDEBUG
-#define FULLSCREEN SDL_WINDOW_FULLSCREEN
-#else
-#define FULLSCREEN 0
-#endif
-
-    if (!windowed && FULLSCREEN) {
-        fullscreen = FULLSCREEN;
-    }
-
     /* 8-bit surface for game to write directly to */
     screen = SDL_CreateRGBSurface(0,
                                   X_RESOLUTION, Y_RESOLUTION,
@@ -86,7 +76,7 @@ void initGraphics()
     window = SDL_CreateWindow("KOPS", SDL_WINDOWPOS_UNDEFINED,
                               SDL_WINDOWPOS_UNDEFINED,
                               screen->w, screen->h,
-                              fullscreen | SDL_WINDOW_OPENGL);
+                              SDL_WINDOW_OPENGL);
 
     if (window == NULL) {
         sprintf(sdf, "Couldn't set 640x480x8 video mode: %s\n", SDL_GetError());


### PR DESCRIPTION
Start game always on windowed mode, regardless of build variant.

@akheron at Slack:
> Oisko se enemmän tätä päivää että laitettais se myös käynnistymään ikkunassa aina?

I agree. Current full screen mode on startup changes desktop resolution to 640x480 which doesn't work on all modern setups. It could be changed to use desktop resolution (like Alt + Enter toggling does), but I too prefer windowed.